### PR TITLE
feat: parse input regexs to an nfa

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,9 @@ ThisBuild / scalaVersion := "3.6.4"
 
 val projectName = "scala-parser-generator"
 
+
 lazy val root = (project in file("."))
   .settings(
-    name := projectName
+    name := projectName,
+    libraryDependencies += "org.scalatest" %% "scalatest" % "3.3.0-SNAP4"
   )

--- a/src/main/scala/lexer/Automata.scala
+++ b/src/main/scala/lexer/Automata.scala
@@ -1,0 +1,120 @@
+package lexer
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable
+
+val epsilon = None
+
+object UniqueIdGenerator {
+  private val counter = new AtomicInteger(0)
+  def nextId(): Int = counter.getAndIncrement()
+}
+
+class State(var transitions: Map[Option[Char], Set[State]] = Map.empty) {
+  val id: Int = UniqueIdGenerator.nextId()
+
+  def addTransition(input: Char, state: State): Unit = addTransition(Some(input), state)
+
+  def addTransition(input: Option[Char], state: State): Unit = {
+    transitions = transitions.updatedWith(input) {
+      case Some(states)  => Some(states + state)
+      case None          => Some(Set(state))
+    }
+  }
+}
+
+object Automata {
+  def empty(): Automata = {
+    val start = State()
+    val end = State()
+    start.addTransition(epsilon, start)
+    Automata(start, Set(end))
+  }
+
+  def const(char: Char): Automata = {
+    val start: State = new State()
+    val end = new State()
+    start.addTransition(char, end)
+    Automata(start, Set(end))
+  }
+
+  def repeat(automata: Automata): Automata = {
+    val first = new State()
+    val last = new State()
+    first.addTransition(epsilon, automata.initial)
+    first.addTransition(epsilon, last)
+    automata.accept.foreach(state => state.addTransition(epsilon, last))
+    automata.accept.foreach(state => state.addTransition(epsilon, automata.initial))
+    Automata(first, Set(last))
+  }
+}
+
+class Automata(val initial: State, var accept: Set[State]) {
+  def ~>(that: Char): Automata = {
+    val automata = Automata.const(that)
+    ~>(automata)
+  }
+
+  def ~>(that: Automata): Automata = {
+    this.accept.foreach(state => state.addTransition(epsilon, that.initial))
+    Automata(this.initial, that.accept)
+  }
+
+  def <|>(that: Automata): Automata = {
+    val first = new State()
+    first.addTransition(epsilon, this.initial)
+    first.addTransition(epsilon, that.initial)
+    val last = new State()
+    this.accept.foreach(state => state.addTransition(epsilon, last))
+    that.accept.foreach(state => state.addTransition(epsilon, last))
+    Automata(first, Set(last))
+  }
+
+  def transitionCount(): Int = {
+    // TODO(JLJ): Factor out duplication with printTransitions.
+    val visited = mutable.Set[Int]()
+    val queue = mutable.Queue[State]()
+    var transitions = 0
+
+    queue.enqueue(this.initial)
+    visited += this.initial.id
+
+    while (queue.nonEmpty) {
+      val state = queue.dequeue()
+      state.transitions.foreach { (char, nextStates) =>
+        val label = char.map(_.toString).getOrElse("ε")
+        nextStates.foreach { next =>
+          transitions += 1
+          if (!visited.contains(next.id)) {
+            visited += next.id
+            queue.enqueue(next)
+          }
+        }
+      }
+    }
+
+    transitions
+  }
+
+  def printTransitions(): Unit = {
+    val visited = mutable.Set[Int]()
+    val queue = mutable.Queue[State]()
+
+    queue.enqueue(this.initial)
+    visited += this.initial.id
+
+    while (queue.nonEmpty) {
+      val state = queue.dequeue()
+      state.transitions.foreach {(char, nextStates) =>
+        val label = char.map(_.toString).getOrElse("ε")
+        nextStates.foreach { next =>
+          println(s"${state.id} --[$label]--> ${next.id}")
+          if (!visited.contains(next.id)) {
+            visited += next.id
+            queue.enqueue(next)
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/lexer/RegExParser.scala
+++ b/src/main/scala/lexer/RegExParser.scala
@@ -1,0 +1,67 @@
+package lexer
+
+import scala.collection.mutable
+
+object RegExParser {
+  private def isOperator(char: Char): Boolean = {
+    // TODO: Fill in the rest
+    char == '|' || char == '(' || char == ')'
+  }
+
+  def parseToNFA(regEx: String): Automata = {
+    // TODO: This could probably be abstracted
+    if (regEx.isEmpty) {
+      return Automata.empty()
+    }
+
+    val automataStack : mutable.Stack[Automata] = mutable.Stack()
+    val operatorStack : mutable.Stack[Char] = mutable.Stack()
+
+    for (c <- regEx) {
+      if ((c == '|' || c == ')') && operatorStack.nonEmpty && operatorStack.top == '|') {
+        if (automataStack.size < 2) throw new Error()
+        operatorStack.pop()
+        automataStack.push(automataStack.pop() <|> automataStack.pop())
+      }
+      c match {
+        case '(' => operatorStack.push(c)
+        case ')' =>
+          if (operatorStack.isEmpty || operatorStack.top != '(') throw new Error()
+          operatorStack.pop()
+
+        // TODO: Check open bracket is top operator
+        case '|' =>
+          operatorStack.push(c)
+
+        case '*' =>
+          if (automataStack.isEmpty) throw new Error()
+          automataStack.push(Automata.repeat(automataStack.pop()))
+
+        case _ =>
+          if (automataStack.size >= 2)  {
+            val second = automataStack.pop()
+            val first = automataStack.pop()
+            automataStack.push(first ~> second)
+          }
+          automataStack.push(Automata.const(c))
+      }
+    }
+
+    if (automataStack.size == 2 && operatorStack.isEmpty) {
+      val second = automataStack.pop()
+      val first = automataStack.pop()
+      return first ~> second
+    } else if (automataStack.size == 2 && operatorStack.size == 1 && operatorStack.top == '|') {
+      val second = automataStack.pop()
+      val first = automataStack.pop()
+      return first <|> second
+    }
+    automataStack.top
+  }
+
+}
+
+
+@main def main(): Unit = {
+  RegExParser.parseToNFA("(a|b)*").printTransitions()
+}

--- a/src/test/scala/AutomataTests.scala
+++ b/src/test/scala/AutomataTests.scala
@@ -1,0 +1,24 @@
+class AutomataTests
+
+import org.scalatest.flatspec.AnyFlatSpec
+import lexer.{Automata, State}
+
+import scala.collection.mutable
+
+class AutomataFlatSpec extends AnyFlatSpec {
+  "An empty Automata" should "have one transition" in {
+    assert(Automata.empty().transitionCount() == 1)
+  }
+
+  "An empty Automata" should "have an epsilon transition" in {
+    assert(Automata.empty().initial.transitions.head._1.isEmpty)
+  }
+
+  "A constant Automata" should "have one transition" in {
+    assert(Automata.const('a').transitionCount() == 1)
+  }
+
+  "A constant Automata" should "have a transition matching the constant" in {
+    assert(Automata.const('a').initial.transitions.head._1.contains('a'))
+  }
+}

--- a/src/test/scala/RegExParserTests.scala
+++ b/src/test/scala/RegExParserTests.scala
@@ -1,0 +1,27 @@
+class RegExParserTests
+import org.scalatest.flatspec.AnyFlatSpec
+import lexer.RegExParser
+
+import scala.collection.mutable
+
+class RegExFlatSpec extends AnyFlatSpec {
+  "An empty Automata" should "have one transition" in {
+    val nfa = RegExParser.parseToNFA("")
+    assert(nfa.transitionCount() == 1)
+  }
+
+  "An empty Automata" should "have an epsilon transition" in {
+    val nfa = RegExParser.parseToNFA("")
+    assert(nfa.initial.transitions.head._1.isEmpty)
+  }
+
+  "A constant Automata" should "have one transition" in {
+    val nfa = RegExParser.parseToNFA("a")
+    assert(nfa.transitionCount() == 1)
+  }
+
+  "A constant Automata" should "have a transition matching the constant" in {
+    val nfa = RegExParser.parseToNFA("a")
+    assert(nfa.initial.transitions.head._1.contains('a'))
+  }
+}


### PR DESCRIPTION
Parse basic regular expressions featuring the operators `|`, `*` and brackets to a non-determanistic finite automata (NFA).

Fixes: #3