### PR TITLE
refactor(nfa): rename automata to nfa

### DIFF
--- a/src/main/scala/lexer/NFA.scala
+++ b/src/main/scala/lexer/NFA.scala
@@ -23,51 +23,51 @@ class State(var transitions: Map[Option[Char], Set[State]] = Map.empty) {
   }
 }
 
-object Automata {
-  def empty(): Automata = {
+object NFA {
+  def empty(): NFA = {
     val start = State()
     val end = State()
     start.addTransition(epsilon, start)
-    Automata(start, Set(end))
+    NFA(start, Set(end))
   }
 
-  def const(char: Char): Automata = {
+  def const(char: Char): NFA = {
     val start: State = new State()
     val end = new State()
     start.addTransition(char, end)
-    Automata(start, Set(end))
+    NFA(start, Set(end))
   }
 
-  def repeat(automata: Automata): Automata = {
+  def repeat(automata: NFA): NFA = {
     val first = new State()
     val last = new State()
     first.addTransition(epsilon, automata.initial)
     first.addTransition(epsilon, last)
     automata.accept.foreach(state => state.addTransition(epsilon, last))
     automata.accept.foreach(state => state.addTransition(epsilon, automata.initial))
-    Automata(first, Set(last))
+    NFA(first, Set(last))
   }
 }
 
-class Automata(val initial: State, var accept: Set[State]) {
-  def ~>(that: Char): Automata = {
-    val automata = Automata.const(that)
+class NFA(val initial: State, var accept: Set[State]) {
+  def ~>(that: Char): NFA = {
+    val automata = NFA.const(that)
     ~>(automata)
   }
 
-  def ~>(that: Automata): Automata = {
+  def ~>(that: NFA): NFA = {
     this.accept.foreach(state => state.addTransition(epsilon, that.initial))
-    Automata(this.initial, that.accept)
+    NFA(this.initial, that.accept)
   }
 
-  def <|>(that: Automata): Automata = {
+  def <|>(that: NFA): NFA = {
     val first = new State()
     first.addTransition(epsilon, this.initial)
     first.addTransition(epsilon, that.initial)
     val last = new State()
     this.accept.foreach(state => state.addTransition(epsilon, last))
     that.accept.foreach(state => state.addTransition(epsilon, last))
-    Automata(first, Set(last))
+    NFA(first, Set(last))
   }
 
   def transitionCount(): Int = {

--- a/src/main/scala/lexer/RegExParser.scala
+++ b/src/main/scala/lexer/RegExParser.scala
@@ -8,13 +8,13 @@ object RegExParser {
     char == '|' || char == '(' || char == ')'
   }
 
-  def parseToNFA(regEx: String): Automata = {
+  def parseToNFA(regEx: String): NFA = {
     // TODO: This could probably be abstracted
     if (regEx.isEmpty) {
-      return Automata.empty()
+      return NFA.empty()
     }
 
-    val automataStack : mutable.Stack[Automata] = mutable.Stack()
+    val automataStack : mutable.Stack[NFA] = mutable.Stack()
     val operatorStack : mutable.Stack[Char] = mutable.Stack()
 
     for (c <- regEx) {
@@ -35,7 +35,7 @@ object RegExParser {
 
         case '*' =>
           if (automataStack.isEmpty) throw new Error()
-          automataStack.push(Automata.repeat(automataStack.pop()))
+          automataStack.push(NFA.repeat(automataStack.pop()))
 
         case _ =>
           if (automataStack.size >= 2)  {
@@ -43,7 +43,7 @@ object RegExParser {
             val first = automataStack.pop()
             automataStack.push(first ~> second)
           }
-          automataStack.push(Automata.const(c))
+          automataStack.push(NFA.const(c))
       }
     }
 
@@ -59,9 +59,4 @@ object RegExParser {
     automataStack.top
   }
 
-}
-
-
-@main def main(): Unit = {
-  RegExParser.parseToNFA("(a|b)*").printTransitions()
 }


### PR DESCRIPTION
Since NFAs and DFAs have different properties, they should be represented by individual classes that enforce the difference. For example, in a DFA there should be a unique edge for each label leaving a node.