### PR TITLE
feat: add lexer dsl

### DIFF
--- a/src/main/scala/lexer/Automata.scala
+++ b/src/main/scala/lexer/Automata.scala
@@ -45,7 +45,6 @@ trait AutomataState[T <: AutomataState[T, F], F[_]] {
 
 extension [T <: AutomataState[T, F], F[_]](iterable: Iterable[T])
   private def ids(): Set[Int] = iterable.map(state => state.id).toSet
-  
 
 trait Automata[S <: AutomataState[S, F], F[A] <: Iterable[A]] {
   def initial: S

--- a/src/main/scala/lexer/Automata.scala
+++ b/src/main/scala/lexer/Automata.scala
@@ -43,6 +43,10 @@ trait AutomataState[T <: AutomataState[T, F], F[_]] {
   def addTransition(input: Option[Char], state: T): Unit
 }
 
+extension [T <: AutomataState[T, F], F[_]](iterable: Iterable[T])
+  private def ids(): Set[Int] = iterable.map(state => state.id).toSet
+  
+
 trait Automata[S <: AutomataState[S, F], F[A] <: Iterable[A]] {
   def initial: S
   def accept: Set[S]

--- a/src/main/scala/lexer/Automata.scala
+++ b/src/main/scala/lexer/Automata.scala
@@ -70,7 +70,6 @@ trait Automata[S <: AutomataState[S, F], F[A] <: Iterable[A]] {
   ): Unit = {
     val visited = mutable.Set[Int]()
     val queue = mutable.Queue[S]()
-    var transitions = 0
 
     queue.enqueue(initial)
     visited += initial.id
@@ -101,6 +100,20 @@ trait Automata[S <: AutomataState[S, F], F[A] <: Iterable[A]] {
     traverse((_, _) => nodeCount += 1, (), (_, _) => transitionCount += 1, ())
 
     (nodeCount, transitionCount)
+  }
+
+  def nodeIdRange(): (Int, Int) = {
+    var minimum = Int.MaxValue
+    var maximum = 0
+    traverse(
+      (s, _) => { minimum = minimum.min(s.id); maximum = maximum.max(s.id) },
+      (),
+      (_, _) => (),
+      ()
+    )
+    println(minimum)
+    println(maximum)
+    (minimum, maximum)
   }
 
   /** Print the transitions in the current Automata.

--- a/src/main/scala/lexer/DFA.scala
+++ b/src/main/scala/lexer/DFA.scala
@@ -117,10 +117,12 @@ def nfaToDfa(nfa: NFA): (DFA, Map[Int, Set[Int]]) = {
         if (reachableAccepting.nonEmpty) {
           dfaAccepting += newRepresentative
           // TODO: Tidy this up
-          reachableAccepting.foreach(id => nfaToDfaAccept.updateWith(id) {
-            case Some(states) => Some(states + newRepresentative.id)
-            case None         => Some(Set(newRepresentative.id))
-          })
+          reachableAccepting.foreach(id =>
+            nfaToDfaAccept.updateWith(id) {
+              case Some(states) => Some(states + newRepresentative.id)
+              case None         => Some(Set(newRepresentative.id))
+            }
+          )
         }
       } else {
         // If the set of states has been visited before, add a transition to the existing representative

--- a/src/main/scala/lexer/DFA.scala
+++ b/src/main/scala/lexer/DFA.scala
@@ -75,6 +75,8 @@ def nfaToDfa(nfa: NFA): DFA = {
   val workQueue = mutable.Queue[(Set[NFAState], DFAState)]()
   workQueue.enqueue((q0, dfaInitial))
 
+  val nfaAcceptingIds = nfa.accept.map(state => state.id)
+
   while (workQueue.nonEmpty) {
     // Get the next element form the workQueue
     val (q, representative) = workQueue.dequeue()
@@ -106,6 +108,8 @@ def nfaToDfa(nfa: NFA): DFA = {
         representative.addTransition(char, newRepresentative)
         visited += (reachableIdSet -> newRepresentative)
         workQueue.enqueue((reachable, newRepresentative))
+        if (reachableIdSet.intersect(nfaAcceptingIds).nonEmpty)
+          dfaAccepting += newRepresentative
       } else {
         // If the set of states has been visited before, add a transition to the existing representative
         // to show that it can be reached from the current state.

--- a/src/main/scala/lexer/ErrorBuilder.scala
+++ b/src/main/scala/lexer/ErrorBuilder.scala
@@ -1,0 +1,40 @@
+package lexer
+
+trait ErrorBuilder[Err] {
+  def build(pos: Position, lines: ErrorInfoLines): Err
+
+  def pos(line: Int, column: Int): Position
+
+  def unexpected(unexpected: Char, expected: Set[Char]): ErrorInfoLines
+
+  type Position
+  type ErrorInfoLines
+  type Unexpected
+  type Expected
+}
+
+type Pos = (Int, Int)
+
+case class LexerError(pos: Pos, errorInfo: String) {
+  def format: String = {
+    s"Lexer error at (${pos._1}, ${pos._2}): $errorInfo"
+  }
+}
+
+class DefaultErrorBuilder extends ErrorBuilder[LexerError] {
+  override def build(pos: Position, lines: ErrorInfoLines): LexerError =
+    LexerError(pos, lines)
+
+  override def unexpected(
+      unexpected: Unexpected,
+      expected: Expected
+  ): ErrorInfoLines =
+    s"Unexpected character: $unexpected. Expected one of: ${expected.mkString(", ")}"
+
+  override def pos(line: Int, column: Int): Position = (line, column)
+
+  override type Position = Pos
+  override type ErrorInfoLines = String
+  override type Unexpected = Char
+  override type Expected = Set[Char]
+}

--- a/src/main/scala/lexer/Lexer.scala
+++ b/src/main/scala/lexer/Lexer.scala
@@ -21,15 +21,15 @@ object Lexer {
     import ctx.reflect.*
     // Parse the input regular expressions to an internal representation and error if they cannot be parsed.
     val parsed: Seq[(RegEx, T)] = regexToTokens match {
-      case Varargs(args) => args.map {
-        case '{ RegexToToken($regex, $token) } =>
+      case Varargs(args) =>
+        args.map { case '{ RegexToToken($regex, $token) } =>
           val lexed = Scanner.scan(regex.valueOrAbort)
           Parser.parseRegex(lexed) match {
             case Right(value) => (value, token.asInstanceOf[T])
             case Left(error) =>
               report.error(error.format); (Emp, ???)
           }
-      }
+        }
     }
 
     // Convert each regular expression to an NFA
@@ -86,7 +86,11 @@ object Lexer {
           var lexeme: String = ""
           val stack = mutable.Stack[(Int, Int)]((bad, bad))
 
-          while (state != error && (pointer < string.length) && !failed.contains(bitSetIndex(pointer, state))) {
+          while (
+            state != error && (pointer < string.length) && !failed.contains(
+              bitSetIndex(pointer, state)
+            )
+          ) {
             // Get the next character and add it to the lexeme
             val char = string(pointer)
             pointer += 1
@@ -125,42 +129,6 @@ object Lexer {
       }
     }
 
-//    val lexDecl: Symbol => Symbol = cls => Symbol.newMethod(cls, "lex", MethodType(List("input"))(_ => List(TypeRepr.of[String]), _ => TypeRepr.of[List[T]]))
-//
-//    val decls: Symbol => List[Symbol] = cls => lexDecl(cls) :: dfa.accept.map { state =>
-//      val name = s"state${state.id}"
-//      Symbol.newMethod(cls, name, MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]))
-//    }.toList
-//
-//
-//    val classSymb = Symbol.newClass(
-//      Symbol.spliceOwner,
-//      "GeneratedLexer",
-//      parents = List(TypeTree.of[Lexer[T]].tpe),
-//      decls = decls,
-//      selfType = None
-//    )
-//
-//    val methods: List[Statement] = dfa.accept.map { state =>
-//      val name = s"state${state.id}"
-//      val methodSymb = classSymb.declaredMethod(name).head
-//      val body = '{ println("Test") }.asTerm
-//      DefDef(methodSymb, argss => Some(body))
-//    }.toList
-//
-//    val lex: Statement = DefDef(classSymb.declaredMethod("lex").head, args => Some('{ println("HELLO WORLD"); List() }.asTerm))
-//
-//
-//    val classDef = ClassDef(
-//      classSymb,
-//      List(),
-//      body = lex :: methods
-//    )
-//
-//
-//
-//    val newClassExpr = Typed(Block(List(classDef), New(TypeIdent(classSymb))), TypeTree.of[Lexer[T]])
-//    newClassExpr.asExprOf[Lexer[T]]
     result
   }
 }
@@ -168,24 +136,3 @@ object Lexer {
 abstract class Lexer[T]() {
   def lex(input: String): List[T]
 }
-//class Lexer[T](private val regexToToken: RegexToToken[T]*) {
-//
-//  def output(outputStream: OutputStream): Unit = {
-//    val parseResult = regexToToken.map(regexToToken =>
-//      Parser.parseRegex(Scanner.scan(regexToToken.regex))
-//    )
-//
-//    val errors = parseResult.filter(res => res.isLeft)
-//    if (errors.nonEmpty) { /* Error */ }
-//
-//    val nfas = parseResult.map {
-//      case Right(regEx) => regexToNfa(regEx)
-//      case Left(_)      => NFA.empty() // Can't happen
-//    }
-//
-//    val nfa = NFA.combine(nfas)
-//    val dfa = nfaToDfa(nfa)
-//
-//    outputDfa(dfa, outputStream)
-//  }
-//}

--- a/src/main/scala/lexer/Lexer.scala
+++ b/src/main/scala/lexer/Lexer.scala
@@ -153,14 +153,15 @@ object Lexer {
 
             if transitions.contains((state, char))
             then state = transitions((state, char))
-            else {
+            else state = error
+
+            if (state == error || pointer >= string.length) {
               errorMessage = Some(
                 eb.build(
                   eb.pos(pointer, 0),
                   eb.unexpected(char, expected = validTransitions.getOrElse(state, Set.empty))
                 )
               )
-              state = error
             }
           }
 

--- a/src/main/scala/lexer/Lexer.scala
+++ b/src/main/scala/lexer/Lexer.scala
@@ -1,0 +1,191 @@
+package lexer
+
+import lexer.NFA.{combine, repeat}
+
+import scala.collection.mutable
+import scala.quoted.*
+
+extension (regex: String)
+  inline def ->[T](inline token: T): RegexToToken[T] =
+    RegexToToken(regex, token)
+
+case class RegexToToken[T](regex: String, token: T)
+
+object Lexer {
+  inline def apply[T](inline regexToTokens: RegexToToken[T]*): Lexer[T] =
+    ${ applyImpl('{ regexToTokens }) }
+
+  private def applyImpl[T: Type](
+      regexToTokens: Expr[Seq[RegexToToken[T]]]
+  )(using ctx: Quotes): Expr[Lexer[T]] = {
+    import ctx.reflect.*
+    // Parse the input regular expressions to an internal representation and error if they cannot be parsed.
+    val parsed: Seq[(RegEx, T)] = regexToTokens match {
+      case Varargs(args) => args.map {
+        case '{ RegexToToken($regex, $token) } =>
+          val lexed = Scanner.scan(regex.valueOrAbort)
+          Parser.parseRegex(lexed) match {
+            case Right(value) => (value, token.asInstanceOf[T])
+            case Left(error) =>
+              report.error(error.format); (Emp, ???)
+          }
+      }
+    }
+
+    // Convert each regular expression to an NFA
+    val nfas = parsed.map { (regex, _) =>
+      regexToNfa(regex)
+    }
+
+    // Combine the NFAs into one NFA
+    val combinedNfa = combine(nfas)
+
+    // Convert the NFA into a DFA
+    val dfa = nfaToDfa(combinedNfa)
+
+    val (minId, maxId) = dfa.nodeIdRange()
+    val acceptingStates: Expr[Seq[Int]] = Expr(
+      dfa.accept.toSeq.map(s => s.id - minId)
+    )
+    val transitionMap = mutable.HashMap[(Int, Char), Int]()
+    dfa.traverse(
+      (_, _) => (),
+      (),
+      (transition, map: mutable.HashMap[(Int, Char), Int]) => {
+        if transition._2.nonEmpty then
+          map += ((
+            transition._1.id - minId,
+            transition._2.get
+          ) -> (transition._3.id - minId))
+      },
+      transitionMap
+    )
+
+    val transitionSeq: Expr[Seq[((Int, Char), Int)]] = Expr(transitionMap.toSeq)
+
+    val result = '{
+      new Lexer[T] {
+        private var string: String = ""
+        private var pointer: Int = 0
+
+        private val transitions =
+          mutable.HashMap[(Int, Char), Int]().addAll { ${ transitionSeq } }
+        private val accept: mutable.HashSet[Int] =
+          mutable.HashSet().addAll { ${ acceptingStates } }
+
+        private val failed = mutable.BitSet()
+
+        private val bad = -2
+        private val error = -1
+
+        private def bitSetIndex(pointer: Int, state: Int): Int =
+          pointer * (${ Expr(maxId) } - ${ Expr(minId) }) + state
+
+        private def nextWord(): Unit = {
+          var state: Int = ${ Expr(dfa.initial.id - minId) }
+          var lexeme: String = ""
+          val stack = mutable.Stack[(Int, Int)]((bad, bad))
+
+          while (state != error && (pointer < string.length) && !failed.contains(bitSetIndex(pointer, state))) {
+            // Get the next character and add it to the lexeme
+            val char = string(pointer)
+            pointer += 1
+            lexeme += char
+
+            if (accept.contains(state)) stack.clear()
+
+            stack.push((state, pointer))
+
+            if transitions.contains((state, char))
+            then state = transitions((state, char))
+            else state = error
+          }
+
+          while (state != bad && !accept.contains(state)) {
+            failed += bitSetIndex(pointer, state)
+            val (s, pos) = stack.pop()
+            state = s
+            pointer = pos
+            lexeme.dropRight(1)
+            pointer -= 1
+          }
+
+          if accept.contains(state)
+          then println("Accept")
+          else println("Reject")
+        }
+
+        override def lex(input: String): List[T] = {
+          string = input
+          while (0 <= pointer && pointer < string.length) {
+            nextWord()
+          }
+          List()
+        }
+      }
+    }
+
+//    val lexDecl: Symbol => Symbol = cls => Symbol.newMethod(cls, "lex", MethodType(List("input"))(_ => List(TypeRepr.of[String]), _ => TypeRepr.of[List[T]]))
+//
+//    val decls: Symbol => List[Symbol] = cls => lexDecl(cls) :: dfa.accept.map { state =>
+//      val name = s"state${state.id}"
+//      Symbol.newMethod(cls, name, MethodType(Nil)(_ => Nil, _ => TypeRepr.of[Unit]))
+//    }.toList
+//
+//
+//    val classSymb = Symbol.newClass(
+//      Symbol.spliceOwner,
+//      "GeneratedLexer",
+//      parents = List(TypeTree.of[Lexer[T]].tpe),
+//      decls = decls,
+//      selfType = None
+//    )
+//
+//    val methods: List[Statement] = dfa.accept.map { state =>
+//      val name = s"state${state.id}"
+//      val methodSymb = classSymb.declaredMethod(name).head
+//      val body = '{ println("Test") }.asTerm
+//      DefDef(methodSymb, argss => Some(body))
+//    }.toList
+//
+//    val lex: Statement = DefDef(classSymb.declaredMethod("lex").head, args => Some('{ println("HELLO WORLD"); List() }.asTerm))
+//
+//
+//    val classDef = ClassDef(
+//      classSymb,
+//      List(),
+//      body = lex :: methods
+//    )
+//
+//
+//
+//    val newClassExpr = Typed(Block(List(classDef), New(TypeIdent(classSymb))), TypeTree.of[Lexer[T]])
+//    newClassExpr.asExprOf[Lexer[T]]
+    result
+  }
+}
+
+abstract class Lexer[T]() {
+  def lex(input: String): List[T]
+}
+//class Lexer[T](private val regexToToken: RegexToToken[T]*) {
+//
+//  def output(outputStream: OutputStream): Unit = {
+//    val parseResult = regexToToken.map(regexToToken =>
+//      Parser.parseRegex(Scanner.scan(regexToToken.regex))
+//    )
+//
+//    val errors = parseResult.filter(res => res.isLeft)
+//    if (errors.nonEmpty) { /* Error */ }
+//
+//    val nfas = parseResult.map {
+//      case Right(regEx) => regexToNfa(regEx)
+//      case Left(_)      => NFA.empty() // Can't happen
+//    }
+//
+//    val nfa = NFA.combine(nfas)
+//    val dfa = nfaToDfa(nfa)
+//
+//    outputDfa(dfa, outputStream)
+//  }
+//}

--- a/src/main/scala/lexer/Lexer.scala
+++ b/src/main/scala/lexer/Lexer.scala
@@ -159,7 +159,10 @@ object Lexer {
               errorMessage = Some(
                 eb.build(
                   eb.pos(pointer, 0),
-                  eb.unexpected(char, expected = validTransitions.getOrElse(state, Set.empty))
+                  eb.unexpected(
+                    char,
+                    expected = validTransitions.getOrElse(state, Set.empty)
+                  )
                 )
               )
             }

--- a/src/main/scala/lexer/Main.scala
+++ b/src/main/scala/lexer/Main.scala
@@ -1,6 +1,4 @@
 package lexer
 
 @main
-def main(outputFilePath: String): Unit = {
-
-}
+def main(outputFilePath: String): Unit = {}

--- a/src/main/scala/lexer/Main.scala
+++ b/src/main/scala/lexer/Main.scala
@@ -1,12 +1,6 @@
 package lexer
 
-import java.io.{File, FileOutputStream}
-import scala.annotation.experimental
-import scala.sys.exit
-
 @main
 def main(outputFilePath: String): Unit = {
-  val lexer = Lexer("ab" -> (), "aba" -> ())
-  lexer.lex("aba")
 
 }

--- a/src/main/scala/lexer/Main.scala
+++ b/src/main/scala/lexer/Main.scala
@@ -1,4 +1,12 @@
 package lexer
 
+import java.io.{File, FileOutputStream}
+import scala.annotation.experimental
+import scala.sys.exit
+
 @main
-def main(): Unit = {}
+def main(outputFilePath: String): Unit = {
+  val lexer = Lexer("ab" -> (), "aba" -> ())
+  lexer.lex("aba")
+
+}

--- a/src/main/scala/lexer/NFA.scala
+++ b/src/main/scala/lexer/NFA.scala
@@ -1,5 +1,7 @@
 package lexer
 
+import scala.collection.mutable
+
 /** A state in the NFA graph.
   *
   * @param transitions
@@ -30,7 +32,7 @@ object NFA {
     *   An empty NFA.
     */
   def empty(): NFA = const(None)
-
+  
   /** Produce a constant NFA with a single transition.
     * @param char
     *   The character associated with the single transition.
@@ -44,6 +46,17 @@ object NFA {
     val end = NFAState()
     start.addTransition(char, end)
     NFA(start, Set(end))
+  }
+
+
+  def combine(nfas: Seq[NFA]): NFA = {
+    val initial = NFAState()
+    var accept = Set[NFAState]()
+    nfas.foreach(nfa => 
+      initial.addTransition(epsilon, nfa.initial)
+      accept = accept.union(nfa.accept)
+    ) 
+    NFA(initial, accept)
   }
 
   /** Produce an NFA that can be repeated zero or more times.

--- a/src/main/scala/lexer/NFA.scala
+++ b/src/main/scala/lexer/NFA.scala
@@ -32,7 +32,7 @@ object NFA {
     *   An empty NFA.
     */
   def empty(): NFA = const(None)
-  
+
   /** Produce a constant NFA with a single transition.
     * @param char
     *   The character associated with the single transition.
@@ -48,14 +48,13 @@ object NFA {
     NFA(start, Set(end))
   }
 
-
   def combine(nfas: Seq[NFA]): NFA = {
     val initial = NFAState()
     var accept = Set[NFAState]()
-    nfas.foreach(nfa => 
+    nfas.foreach(nfa =>
       initial.addTransition(epsilon, nfa.initial)
       accept = accept.union(nfa.accept)
-    ) 
+    )
     NFA(initial, accept)
   }
 

--- a/src/main/scala/lexer/ParseError.scala
+++ b/src/main/scala/lexer/ParseError.scala
@@ -1,6 +1,6 @@
 package lexer
 
-case class ParseError(val message: String, val position: SourcePosition) {
+case class ParseError(message: String, position: SourcePosition) {
   def format: String = {
     s"Parse error at (${position.line}, ${position.column}): $message"
   }

--- a/src/test/scala/LexerTest.scala
+++ b/src/test/scala/LexerTest.scala
@@ -1,7 +1,9 @@
 class LexerTest
 
-import lexer.{Lexer, ->}
+import lexer.{->, Lexer}
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers.matchPattern
+import org.scalatest.matchers.should.Matchers.should
 
 // Resulting tokens to be used for testing
 sealed trait LexerTok
@@ -13,28 +15,79 @@ case object Tok4 extends LexerTok
 class LexerFlatSpec extends AnyFlatSpec {
   "Lexer" should "lex constants correctly" in {
     val lexer = Lexer("a" -> Tok1)
-    assert(lexer.lex("a") === List(Tok1))
-    assert(lexer.lex("b") === List())
-    assert(lexer.lex("ab") === List(Tok1))
+    lexer.lex("a") should matchPattern { case Right(List(Tok1)) => }
+    lexer.lex("b") should matchPattern { case Left(_) => }
+    lexer.lex("abb") should matchPattern { case Left(_) => }
   }
 
   "Lexer" should "lex sequences correctly" in {
     val lexer = Lexer("abc" -> Tok2)
-    assert(lexer.lex("a") === List())
-    assert(lexer.lex("b") === List())
-    assert(lexer.lex("ab") === List())
-    assert(lexer.lex("abc") === List(Tok2))
-    assert(lexer.lex("abcd") === List(Tok2))
-    assert(lexer.lex("aalksd") === List())
+    lexer.lex("a") should matchPattern { case Left(_) => }
+    lexer.lex("b") should matchPattern { case Left(_) => }
+    lexer.lex("ab") should matchPattern { case Left(_) => }
+    lexer.lex("abc") should matchPattern { case Right(List(Tok2)) => }
+    lexer.lex("alhkhd") should matchPattern { case Left(_) => }
+    lexer.lex("abcabc") should matchPattern { case Right(List(Tok2, Tok2)) => }
+    lexer.lex("abca") should matchPattern { case Left(_) => }
   }
 
   "Lexer" should "lex closure correctly" in {
     val lexer = Lexer("a*" -> Tok3)
-    assert(lexer.lex("a") === List(Tok3))
-    assert(lexer.lex("b") === List())
-    assert(lexer.lex("ab") === List())
-    assert(lexer.lex("aaaaaaaa") === List(Tok3))
-    assert(lexer.lex("aba") === List(Tok3))
-    assert(lexer.lex("baaaaaaaa") === List())
+    lexer.lex("a") should matchPattern { case Right(List(Tok3)) => }
+    lexer.lex("b") should matchPattern { case Left(_) => }
+    lexer.lex("ab") should matchPattern { case Left(_) => }
+    lexer.lex("aaaaaaaa") should matchPattern { case Right(List(Tok3)) => }
+    lexer.lex("aba") should matchPattern { case Left(_) => }
+    lexer.lex("baaaaaaaa") should matchPattern { case Left(_) => }
+  }
+
+  "Lexer" should "lex alternation correctly" in {
+    val lexer = Lexer("c|d" -> Tok1)
+    lexer.lex("c") should matchPattern { case Right(List(Tok1)) => }
+    lexer.lex("d") should matchPattern { case Right(List(Tok1)) => }
+    lexer.lex("ccccc") should matchPattern { case Right(List(Tok1, Tok1, Tok1, Tok1, Tok1)) => }
+    lexer.lex("dddd") should matchPattern { case Right(List(Tok1, Tok1, Tok1, Tok1)) => }
+    lexer.lex("cdcd") should matchPattern { case Right(List(Tok1, Tok1, Tok1, Tok1)) => }
+    lexer.lex("Hello World") should matchPattern { case Left(_) => }
+    lexer.lex("acd") should matchPattern { case Left(_) => }
+    lexer.lex("cad") should matchPattern { case Left(_) => }
+    lexer.lex("cda") should matchPattern { case Left(_) => }
+  }
+
+  "Lexer" should "lex a combination of constructs correctly" in {
+    val lexer = Lexer("a|1*" -> Tok2)
+    lexer.lex("a") should matchPattern { case Right(List(Tok2)) => }
+    lexer.lex("1") should matchPattern { case Right(List(Tok2)) => }
+    lexer.lex("a1") should matchPattern { case Right(List(Tok2, Tok2)) => }
+    lexer.lex("a11111111") should matchPattern { case Right(List(Tok2, Tok2)) => }
+    lexer.lex("11111111a") should matchPattern { case Right(List(Tok2, Tok2)) => }
+    lexer.lex("1111a1111") should matchPattern { case Right(List(Tok2, Tok2, Tok2)) => }
+    lexer.lex("11a11a1111") should matchPattern { case Right(List(Tok2, Tok2, Tok2, Tok2, Tok2)) => }
+    lexer.lex("a1cd") should matchPattern { case Left(_) => }
+    lexer.lex("ca1d") should matchPattern { case Left(_) => }
+    lexer.lex("1cda") should matchPattern { case Left(_) => }
+  }
+
+  "Lexer" should "produce the correct token when there are multiple options" in {
+    val lexer = Lexer("a" -> Tok1, "b" -> Tok2, "c" -> Tok3)
+    lexer.lex("a") should matchPattern { case Right(List(Tok1)) => }
+    lexer.lex("b") should matchPattern { case Right(List(Tok2)) => }
+    lexer.lex("c") should matchPattern { case Right(List(Tok3)) => }
+    lexer.lex("ab") should matchPattern { case Right(List(Tok1, Tok2)) => }
+    lexer.lex("ac") should matchPattern { case Right(List(Tok1, Tok3)) => }
+    lexer.lex("abc") should matchPattern { case Right(List(Tok1, Tok2, Tok3)) => }
+    lexer.lex("bca") should matchPattern { case Right(List(Tok2, Tok3, Tok1)) => }
+    lexer.lex("cab") should matchPattern { case Right(List(Tok3, Tok1, Tok2)) => }
+  }
+
+  "Lexer" should "match the longest occurrence" in {
+    val lexer1 = Lexer("aa" -> Tok1, "a" -> Tok2)
+    val lexer2 = Lexer("a" -> Tok2, "aa" -> Tok1)
+    lexer1.lex("aa") should matchPattern { case Right(List(Tok1)) => }
+    lexer2.lex("aa") should matchPattern { case Right(List(Tok1)) => }
+    lexer1.lex("aaa") should matchPattern { case Right(List(Tok1, Tok2)) => }
+    lexer2.lex("aaa") should matchPattern { case Right(List(Tok1, Tok2)) => }
+    lexer1.lex("aaaa") should matchPattern { case Right(List(Tok1, Tok1)) => }
+    lexer2.lex("aaaa") should matchPattern { case Right(List(Tok1, Tok1)) => }
   }
 }

--- a/src/test/scala/LexerTest.scala
+++ b/src/test/scala/LexerTest.scala
@@ -45,9 +45,15 @@ class LexerFlatSpec extends AnyFlatSpec {
     val lexer = Lexer("c|d" -> Tok1)
     lexer.lex("c") should matchPattern { case Right(List(Tok1)) => }
     lexer.lex("d") should matchPattern { case Right(List(Tok1)) => }
-    lexer.lex("ccccc") should matchPattern { case Right(List(Tok1, Tok1, Tok1, Tok1, Tok1)) => }
-    lexer.lex("dddd") should matchPattern { case Right(List(Tok1, Tok1, Tok1, Tok1)) => }
-    lexer.lex("cdcd") should matchPattern { case Right(List(Tok1, Tok1, Tok1, Tok1)) => }
+    lexer.lex("ccccc") should matchPattern {
+      case Right(List(Tok1, Tok1, Tok1, Tok1, Tok1)) =>
+    }
+    lexer.lex("dddd") should matchPattern {
+      case Right(List(Tok1, Tok1, Tok1, Tok1)) =>
+    }
+    lexer.lex("cdcd") should matchPattern {
+      case Right(List(Tok1, Tok1, Tok1, Tok1)) =>
+    }
     lexer.lex("Hello World") should matchPattern { case Left(_) => }
     lexer.lex("acd") should matchPattern { case Left(_) => }
     lexer.lex("cad") should matchPattern { case Left(_) => }
@@ -59,10 +65,16 @@ class LexerFlatSpec extends AnyFlatSpec {
     lexer.lex("a") should matchPattern { case Right(List(Tok2)) => }
     lexer.lex("1") should matchPattern { case Right(List(Tok2)) => }
     lexer.lex("a1") should matchPattern { case Right(List(Tok2, Tok2)) => }
-    lexer.lex("a11111111") should matchPattern { case Right(List(Tok2, Tok2)) => }
-    lexer.lex("11111111a") should matchPattern { case Right(List(Tok2, Tok2)) => }
-    lexer.lex("1111a1111") should matchPattern { case Right(List(Tok2, Tok2, Tok2)) => }
-    lexer.lex("11a11a1111") should matchPattern { case Right(List(Tok2, Tok2, Tok2, Tok2, Tok2)) => }
+    lexer.lex("a11111111") should matchPattern { case Right(List(Tok2, Tok2)) =>
+    }
+    lexer.lex("11111111a") should matchPattern { case Right(List(Tok2, Tok2)) =>
+    }
+    lexer.lex("1111a1111") should matchPattern {
+      case Right(List(Tok2, Tok2, Tok2)) =>
+    }
+    lexer.lex("11a11a1111") should matchPattern {
+      case Right(List(Tok2, Tok2, Tok2, Tok2, Tok2)) =>
+    }
     lexer.lex("a1cd") should matchPattern { case Left(_) => }
     lexer.lex("ca1d") should matchPattern { case Left(_) => }
     lexer.lex("1cda") should matchPattern { case Left(_) => }
@@ -75,9 +87,12 @@ class LexerFlatSpec extends AnyFlatSpec {
     lexer.lex("c") should matchPattern { case Right(List(Tok3)) => }
     lexer.lex("ab") should matchPattern { case Right(List(Tok1, Tok2)) => }
     lexer.lex("ac") should matchPattern { case Right(List(Tok1, Tok3)) => }
-    lexer.lex("abc") should matchPattern { case Right(List(Tok1, Tok2, Tok3)) => }
-    lexer.lex("bca") should matchPattern { case Right(List(Tok2, Tok3, Tok1)) => }
-    lexer.lex("cab") should matchPattern { case Right(List(Tok3, Tok1, Tok2)) => }
+    lexer.lex("abc") should matchPattern { case Right(List(Tok1, Tok2, Tok3)) =>
+    }
+    lexer.lex("bca") should matchPattern { case Right(List(Tok2, Tok3, Tok1)) =>
+    }
+    lexer.lex("cab") should matchPattern { case Right(List(Tok3, Tok1, Tok2)) =>
+    }
   }
 
   "Lexer" should "match the longest occurrence" in {

--- a/src/test/scala/LexerTest.scala
+++ b/src/test/scala/LexerTest.scala
@@ -1,0 +1,3 @@
+class LexerTest {
+
+}

--- a/src/test/scala/LexerTest.scala
+++ b/src/test/scala/LexerTest.scala
@@ -1,3 +1,40 @@
-class LexerTest {
+class LexerTest
 
+import lexer.{Lexer, ->}
+import org.scalatest.flatspec.AnyFlatSpec
+
+// Resulting tokens to be used for testing
+sealed trait LexerTok
+case object Tok1 extends LexerTok
+case object Tok2 extends LexerTok
+case object Tok3 extends LexerTok
+case object Tok4 extends LexerTok
+
+class LexerFlatSpec extends AnyFlatSpec {
+  "Lexer" should "lex constants correctly" in {
+    val lexer = Lexer("a" -> Tok1)
+    assert(lexer.lex("a") === List(Tok1))
+    assert(lexer.lex("b") === List())
+    assert(lexer.lex("ab") === List(Tok1))
+  }
+
+  "Lexer" should "lex sequences correctly" in {
+    val lexer = Lexer("abc" -> Tok2)
+    assert(lexer.lex("a") === List())
+    assert(lexer.lex("b") === List())
+    assert(lexer.lex("ab") === List())
+    assert(lexer.lex("abc") === List(Tok2))
+    assert(lexer.lex("abcd") === List(Tok2))
+    assert(lexer.lex("aalksd") === List())
+  }
+
+  "Lexer" should "lex closure correctly" in {
+    val lexer = Lexer("a*" -> Tok3)
+    assert(lexer.lex("a") === List(Tok3))
+    assert(lexer.lex("b") === List())
+    assert(lexer.lex("ab") === List())
+    assert(lexer.lex("aaaaaaaa") === List(Tok3))
+    assert(lexer.lex("aba") === List(Tok3))
+    assert(lexer.lex("baaaaaaaa") === List())
+  }
 }


### PR DESCRIPTION
Make use of Scala's metaprogramming support to do the work of building a lexer at compile time. This allows for an efficient lexer implementaton declared in a Scala source file.

Fixes: #24.