### PR TITLE
fix: correctly parse repeated alternation regexs

### DIFF
--- a/src/main/scala/lexer/Parser.scala
+++ b/src/main/scala/lexer/Parser.scala
@@ -148,7 +148,7 @@ object Parser {
       result <- rest match {
         case PositionedToken(TAlternation, pos) :: tail =>
           for {
-            (rest, rightRegex) <- parseSeq(tail)
+            (rest, rightRegex) <- parseAlternation(tail)
             _ <- rightRegex match {
               case Emp =>
                 Left(

--- a/src/test/scala/ParserTest.scala
+++ b/src/test/scala/ParserTest.scala
@@ -67,10 +67,14 @@ class ParserFlatSpec extends AnyFlatSpec {
       )
     )
     assert(
-      Parser.parseRegex(Scanner.scan("a|b|c")) == Right(Alt(Ch('a'), Alt(Ch('b'), Ch('c'))))
+      Parser.parseRegex(Scanner.scan("a|b|c")) == Right(
+        Alt(Ch('a'), Alt(Ch('b'), Ch('c')))
+      )
     )
     assert(
-      Parser.parseRegex(Scanner.scan("a|b|c|d")) == Right(Alt(Ch('a'), Alt(Ch('b'), Alt(Ch('c'), Ch('d')))))
+      Parser.parseRegex(Scanner.scan("a|b|c|d")) == Right(
+        Alt(Ch('a'), Alt(Ch('b'), Alt(Ch('c'), Ch('d'))))
+      )
     )
   }
 

--- a/src/test/scala/ParserTest.scala
+++ b/src/test/scala/ParserTest.scala
@@ -66,6 +66,12 @@ class ParserFlatSpec extends AnyFlatSpec {
         )
       )
     )
+    assert(
+      Parser.parseRegex(Scanner.scan("a|b|c")) == Right(Alt(Ch('a'), Alt(Ch('b'), Ch('c'))))
+    )
+    assert(
+      Parser.parseRegex(Scanner.scan("a|b|c|d")) == Right(Alt(Ch('a'), Alt(Ch('b'), Alt(Ch('c'), Ch('d')))))
+    )
   }
 
   "Matching brackets" should "parse correctly" in {


### PR DESCRIPTION
Correclty parse regular expressions of the form `a|b|c|...`.

Fixes: #28.